### PR TITLE
Improve Community Project Management

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Community Forum
+    url: https://github.com/UWAppDev/community/discussions
+    about: Ask questions and/or discuss anything.

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -1,0 +1,74 @@
+# https://docs.github.com/en/issues/trying-out-the-new-projects-experience/automating-projects
+name: Add PR to project
+on:
+  pull_request:
+    types:
+      - ready_for_review
+jobs:
+  track_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get project data
+        env:
+          GITHUB_TOKEN: ${{secrets.YOUR_TOKEN}}  # Currently using token from @ApolloZhu
+          ORGANIZATION: UWAppDev
+          PROJECT_NUMBER: 4
+        run: |
+          gh api graphql --header 'GraphQL-Features: projects_next_graphql' -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org){
+                projectNext(number: $number) {
+                  id
+                  fields(first:20) {
+                    nodes {
+                      id
+                      name
+                      settings
+                    }
+                  }
+                }
+              }
+            }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
+
+          echo 'PROJECT_ID='$(jq '.data.organization.projectNext.id' project_data.json) >> $GITHUB_ENV
+          echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
+          echo 'TODO_OPTION_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") | .settings | fromjson.options[] | select(.name=="📬 Todo") | .id' project_data.json) >> $GITHUB_ENV
+
+      - name: Add PR to project
+        env:
+          GITHUB_TOKEN: ${{secrets.YOUR_TOKEN}}
+          PR_ID: ${{ github.event.pull_request.node_id }}
+        run: |
+          item_id="$( gh api graphql --header 'GraphQL-Features: projects_next_graphql' -f query='
+            mutation($project:ID!, $pr:ID!) {
+              addProjectNextItem(input: {projectId: $project, contentId: $pr}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f pr=$PR_ID --jq '.data.addProjectNextItem.projectNextItem.id')"
+          
+          echo 'ITEM_ID='$item_id >> $GITHUB_ENV
+
+      - name: Set fields
+        env:
+          GITHUB_TOKEN: ${{secrets.YOUR_TOKEN}}
+        run: |
+          gh api graphql --header 'GraphQL-Features: projects_next_graphql' -f query='
+            mutation (
+              $project: ID!
+              $item: ID!
+              $status_field: ID!
+              $status_value: String!
+            ) {
+              set_status: updateProjectNextItemField(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $status_field
+                value: $status_value
+              }) {
+                projectNextItem {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value=${{ env.TODO_OPTION_ID }} --silent

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 > What people would call "a forum"
 
-## [Projects](https://github.com/UWAppDev/community/projects)
+## [Projects](https://github.com/orgs/UWAppDev/projects)
 
 > Learn more about active (and past) projects
 


### PR DESCRIPTION
Proposed by @ApolloZhu

1. Use org-level project boards to improve read/write access control by utilizing GitHub teams. See meeting doc https://docs.google.com/document/d/1uM-tleTLJ-PIXZPrmC3PhG20opjTH7xE9Z-XsVlvYtY/edit# for more details.
2. "Disable" creating blank/any issues in this repo. Issues must be enabled to allow adding pull requests from this repo to a board, but having both issues and discussions is confusing, so the workaround is to disable blank issues, and redirect to discussions instead.
3. Automate adding new PR/issues to the Projects (beta) board